### PR TITLE
preserve upper/lower case during alphabet cleanup

### DIFF
--- a/nanoid.cfc
+++ b/nanoid.cfc
@@ -69,7 +69,7 @@ component accessors="true" singleton displayname="CF_NanoID" output="false" hint
 				arguments.alphabet = variables.dictionary[arguments.alphabet];
 			}
 			local.alphabet = javacast("string", arguments.alphabet).replaceAll("[^0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz\-]","");
-			local.alphabet = listRemoveDuplicates(arrayToList(listToArray(local.alphabet, "")), ",", true);
+			local.alphabet = listRemoveDuplicates(arrayToList(listToArray(local.alphabet, "")), ",", false);
 			local.alphabet = local.alphabet.replaceAll(",","");
 			if (listLen(local.alphabet) lt 1 or listLen(local.alphabet) gt 255){
 				throw(message = "alphabet must contain between 1 and 255 unique symbols.");


### PR DESCRIPTION
Fix in the alphabet generation where case sensitivity was being ignored during duplicate removal. Setting ignoreCase=false in listRemoveDuplicates() now properly preserves both uppercase and lowercase characters in the alphabet, ensuring correct character distribution in generated IDs.